### PR TITLE
Deepseek MoE, Union Tokenizer, Forwarding, Consistency

### DIFF
--- a/mergekit/config.py
+++ b/mergekit/config.py
@@ -31,7 +31,7 @@ class ConditionalParameter(BaseModel):
 
 
 ParameterSetting: TypeAlias = Union[
-    ConditionalParameter, List[ConditionalParameter], ScalarOrGradient
+    ConditionalParameter, List[ConditionalParameter], ScalarOrGradient, str
 ]
 
 
@@ -97,17 +97,19 @@ class MergeConfiguration(BaseModel):
     out_dtype: Optional[str] = None
 
     def referenced_models(self) -> List[ModelReference]:
-        models = set()
-        if self.base_model:
-            models.add(self.base_model)
+        models = []
+        if self.base_model and self.base_model not in models:
+            models.append(self.base_model)
         if self.models:
             for model_in in self.models:
-                models.add(model_in.model)
+                if model_in.model not in models:
+                    models.append(model_in.model)
         if self.slices:
             for s in self.slices:
                 for src in s.sources:
-                    models.add(src.model)
-        return list(models)
+                    if src.model not in models:
+                        models.append(src.model)
+        return models
 
     @model_validator(mode="after")
     def validate_inputs(self):

--- a/mergekit/moe/common.py
+++ b/mergekit/moe/common.py
@@ -35,7 +35,7 @@ def initialize_io(
     base_model = config.base_model
     loaders: Dict[ModelReference, LazyTensorLoader] = {}
     for model in tqdm.tqdm(
-        [base_model] + [e.source_model for e in config.experts], desc="Warm up loaders"
+        [base_model] + [e.source_model for e in config.shared_experts] + [e.source_model for e in config.experts], desc="Warm up loaders"
     ):
         loaders[model] = model.lazy_loader(
             cache_dir=merge_options.transformers_cache,

--- a/mergekit/moe/deepseek.py
+++ b/mergekit/moe/deepseek.py
@@ -118,7 +118,7 @@ class DeepseekMoE(MoEOutputArchitecture):
         router_weights: List[torch.Tensor],
         shared_router_weights: Optional[List[torch.Tensor]] = None,
     ):
-        base_model = config.base_model
+        base_model = config.shared_experts[0].source_model
         base_cfg = base_model.config(trust_remote_code=merge_options.trust_remote_code)
 
         out_dtype = select_dtype(config, base_cfg)
@@ -175,7 +175,7 @@ class DeepseekMoE(MoEOutputArchitecture):
             else:
                 copy_tensor_out(
                     weight_info,
-                    base_loader,
+                    shared_loader,
                     writer,
                     out_dtype=out_dtype,
                     clone=merge_options.clone_tensors,

--- a/mergekit/scripts/moe.py
+++ b/mergekit/scripts/moe.py
@@ -42,7 +42,7 @@ def build(
     if is_bad_config(config, allow_all_same=allow_all_same):
         sys.exit(1)
 
-    base_model = config.base_model
+    base_model = config.shared_experts[0].source_model
     out_arch = select_output_arch(config, merge_options, verbose=verbose)
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/mergekit/tokenizer/build.py
+++ b/mergekit/tokenizer/build.py
@@ -16,7 +16,8 @@
 import json
 import logging
 import tempfile
-from typing import Dict, List, Optional, Tuple, Union
+from collections import OrderedDict
+from typing import Dict, List, Optional, Tuple, Union, OrderedDict
 
 import tokenizers
 import tokenizers.models
@@ -110,7 +111,7 @@ def get_stripped_tokenizer(
 
 def build_union_tokenizer(
     base_tok: transformers.PreTrainedTokenizerBase,
-    tokenizers: Dict[ModelReference, transformers.PreTrainedTokenizerBase],
+    tokenizers: OrderedDict[ModelReference, transformers.PreTrainedTokenizerBase],
     trust_remote_code: bool = False,
 ) -> transformers.PreTrainedTokenizerBase:
     out_added_tokens = {}
@@ -199,7 +200,8 @@ def build_tokenizer(
 
     # load all tokenizers
     logging.info("Loading tokenizers")
-    tokenizers = {base_model: tokenizer_base}
+    tokenizers = OrderedDict()
+    tokenizers[base_model] = tokenizer_base
     for model in referenced_models:
         if model == base_model:
             continue


### PR DESCRIPTION
These changes are for my experimental Blackrose model, which is a Deepseek MoE "Clown Car" merge. These changes allow for using a Passthrough merge with multiple models and a chosen "forwarding" model, in order to create a unionized tokenizer from multiple models.

Some of the other changes were made to ensure consistency in the ordering of the tokenizers / models.

This allows you to:
- Select 4 finetunes that may have a different vocab / embedding size
- Create 4 passthrough merges, specifying all 4 models, to create unionized tokenizers for all 4 models with the embeddings ordered properly
- Create a MoE merge using the 4 results, which now has all their tokenizers and embeddings aligned.
- Declare one of the 4 models to be the shared expert in the Deepseek MoE architecture, which becomes the "donor" model instead of the base.